### PR TITLE
Suppress schema validation warnings

### DIFF
--- a/src/applyConnectionTransform.ts
+++ b/src/applyConnectionTransform.ts
@@ -69,6 +69,7 @@ export function applyConnectionTransform({
     schemaDirectives: {
       [directiveName]: ConnectionDirective,
     },
+    resolverValidationOptions: { requireResolversForResolveType: false },
   })
   // console.log('foundObjectTypes', foundObjectTypes)
   // console.log('foundConnections', foundConnections)


### PR DESCRIPTION
I get the following error message:
`Type "Bookmark" is missing a "__resolveType" resolver. Pass false into "resolverValidationOptions.requireResolversForResolveType" to disable this warning.`

This is due to the fact that my Bookmark type is an interface which requires a `__resolveType` to be defined in resolver when building a schema. I believe there is no need for resolvers to be passed to `makeExecutableSchema` when running through the typeDefs to find connection directives. Thus, I've decided to suppress this warning.

PS. Great plugin, exactly what I need in my project.