### PR TITLE
Added support for interfaces

### DIFF
--- a/__tests__/main-test.ts
+++ b/__tests__/main-test.ts
@@ -10,7 +10,11 @@ test('main test', () => {
     ${connectionDirectiveDeclaration}
     directive @sql on FIELD_DEFINITION
 
-    type User {
+    interface Account {
+      interfacePosts: Post @connection
+    }
+
+    type User implements Account {
       userId: Int
       smallPosts: Post @connection
       posts: [Post!]! @sql @connection
@@ -20,6 +24,7 @@ test('main test', () => {
       ): Post @connection
       inlinePosts(myArg: String): Post @connection
       # ignoredPost: Post @connection
+      interfacePosts: Post @connection
     }
 
     type Post {
@@ -36,10 +41,11 @@ test('main test', () => {
   })
   // console.log('final', JSON.stringify(newTypeDefs))
   expect(newTypeDefs).toBe(
-    'type PageInfo {\n  hasNextPage: Boolean!\n  hasPreviousPage: Boolean!\n  startCursor: String\n  endCursor: String\n}\n\ntype PostEdge {\n  cursor: String!\n  node: Post\n}\n\ntype PostConnection {\n  totalCount: Int!\n  edges: [PostEdge]\n  pageInfo: PageInfo!\n}\n\ndirective @connection on FIELD_DEFINITION\n\ndirective @sql on FIELD_DEFINITION\n\ntype User {\n  userId: Int\n  smallPosts(after: String, first: Int, before: String, last: Int): PostConnection\n  posts(after: String, first: Int, before: String, last: Int): PostConnection @sql\n  bigPosts(after: String, first: Int, before: String, last: Int): PostConnection @sql\n  multilinePosts(myArg: String, after: String, first: Int, before: String, last: Int): PostConnection\n  inlinePosts(myArg: String, after: String, first: Int, before: String, last: Int): PostConnection\n}\n\ntype Post {\n  postId: Int\n}\n\ntype Query {\n  user: User\n}\n'
+    'type PageInfo {\n  hasNextPage: Boolean!\n  hasPreviousPage: Boolean!\n  startCursor: String\n  endCursor: String\n}\n\ntype PostEdge {\n  cursor: String!\n  node: Post\n}\n\ntype PostConnection {\n  totalCount: Int!\n  edges: [PostEdge]\n  pageInfo: PageInfo!\n}\n\ndirective @connection on FIELD_DEFINITION\n\ndirective @sql on FIELD_DEFINITION\n\ninterface Account {\n  interfacePosts(after: String, first: Int, before: String, last: Int): PostConnection\n}\n\ntype User implements Account {\n  userId: Int\n  smallPosts(after: String, first: Int, before: String, last: Int): PostConnection\n  posts(after: String, first: Int, before: String, last: Int): PostConnection @sql\n  bigPosts(after: String, first: Int, before: String, last: Int): PostConnection @sql\n  multilinePosts(myArg: String, after: String, first: Int, before: String, last: Int): PostConnection\n  inlinePosts(myArg: String, after: String, first: Int, before: String, last: Int): PostConnection\n  interfacePosts(after: String, first: Int, before: String, last: Int): PostConnection\n}\n\ntype Post {\n  postId: Int\n}\n\ntype Query {\n  user: User\n}\n'
   )
   const finalSchema = makeExecutableSchema({
     typeDefs,
+    resolverValidationOptions: { requireResolversForResolveType: false },
   })
   const errors = validateSchema(finalSchema)
   expect(errors.length).toBe(0)

--- a/src/applyConnectionTransform.ts
+++ b/src/applyConnectionTransform.ts
@@ -17,6 +17,7 @@ import {
   DirectiveLocation,
   DocumentNode,
   ObjectTypeDefinitionNode,
+  InterfaceTypeDefinitionNode,
   print,
 } from 'graphql'
 import gql from 'graphql-tag'
@@ -170,7 +171,7 @@ export function applyConnectionTransform({
   const a = newTypeDefs.concat(originalTypeDefsAsArray)
   const mergedTypeDefs = concatenateTypeDefs(a)
   const document = gql(mergedTypeDefs)
-  const objects = getObjectTypeDefinitions(document)
+  const objects = getValidTypesDefinitions(document)
   objects.forEach(o =>
     getFieldsWithConnectionDirective(o, directiveName).forEach(f => {
       const openField = f as any
@@ -225,12 +226,12 @@ function getCacheControlDirectives(
     : storedCacheValue
 }
 
-function getObjectTypeDefinitions(
+function getValidTypesDefinitions(
   document: DocumentNode
-): ObjectTypeDefinitionNode[] {
+): (ObjectTypeDefinitionNode)[] {
   return document.definitions.filter(
-    d => d.kind === 'ObjectTypeDefinition'
-  ) as ObjectTypeDefinitionNode[]
+    d => d.kind === 'ObjectTypeDefinition' || d.kind === 'InterfaceTypeDefinition'
+  ) as (ObjectTypeDefinitionNode)[]
 }
 
 function getFieldsWithConnectionDirective(


### PR DESCRIPTION
I had to run `--no-verify` because of this. I don't think this is part of my changes.

```
25h× "./node_modules/.bin/prettier --write" found some errors. Please fix them and try committing again.

__tests__\main-test.ts 31ms

[error] src\applyConnectionTransform.ts: SyntaxError: Expression expected. (88:25)
[error]   86 |         foundCacheControl[fieldTypeName] = getCacheControlDirectives(
[error]   87 |           foundCacheControl[fieldTypeName],
[error] > 88 |           field.astNode?.directives
[error]      |                         ^
[error]   89 |         )
[error]   90 |     }
[error]   91 |   }
```